### PR TITLE
Quantity enhancements

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+## v0.1.9
+
+* Ticket forms: Honor a ticket's `min` and `max` quantities ([#14])
+* Ticket forms: default the quantity to `1` if it's the only ticket available ([#14])
+
 ## v0.1.8 - Mar 13, 2015
 
 * Hide fees when an event's fee payer is set to "owner" ([#13])
@@ -70,3 +75,4 @@ Initial preview release
 [#11]: https://github.com/ticketbase/ticketbase-js/issues/11
 [#12]: https://github.com/ticketbase/ticketbase-js/issues/12
 [#13]: https://github.com/ticketbase/ticketbase-js/issues/13
+[#14]: https://github.com/ticketbase/ticketbase-js/issues/14

--- a/docs/Template_variables.md
+++ b/docs/Template_variables.md
@@ -35,6 +35,7 @@ In addition to the attributes in the `event` object as returned by Ticketbase, t
    * `is_free`
    * `has_fees` - true if it has fees
    * `input_quantity_name` - the name for the `<input>` for the quantity box
+   * `quantity_options_html` - a bunch of `<option>` tags
 
 ## `config`
 

--- a/lib/presenters/event.js
+++ b/lib/presenters/event.js
@@ -77,6 +77,8 @@ function getHiddenFields (event, type) {
 function presentTicketTypes (types, event, type) {
   var re = [];
 
+  var onlyHasOne = types.length === 1;
+
   for (var i = 0, len = types.length; i < len; i++) {
     var ticket = types[i];
 
@@ -86,7 +88,11 @@ function presentTicketTypes (types, event, type) {
       ticket.is_free = ticket.ticket_type === 'free';
       ticket.input_quantity_name = 'order[order_items_attributes]['+i+'][quantity]';
       ticket.quantity_options_html =
-        quantityOptions(ticket.min_purchase || 1, ticket.max_purchase || 10);
+        quantityOptions({
+          min: ticket.min_purchase || 1,
+          max: ticket.max_purchase || 10,
+          selected: onlyHasOne ? ticket.min_purchase || 1 : null
+        });
     }
 
     else if (type === 'donation') {
@@ -122,17 +128,25 @@ function addGoal (event) {
 
 /*
  * generates quantity <option> tags
+ *
+ *     quantityOptions(1, 10, { selected: 2 });
  */
 
-function quantityOptions (min, max) {
-  var options = [];
-
-  options.push('<option value="0">0</option>');
+function quantityOptions ({min, max, selected}) {
+  let html = [];
+  html.push(makeOption(0));
 
   for (var i = min; i <= max; i++) {
-    if (i !== 0)
-      options.push('<option value="' + i + '">' + i + '</option>');
+    if (i !== 0) html.push(makeOption(i));
   }
 
-  return options.join("");
+  return html.join("");
+
+  function makeOption (i) {
+    if (selected === i)
+      return '<option value="' + i + '" selected>' + i + '</option>';
+    else
+      return '<option value="' + i + '">' + i + '</option>';
+  }
+
 }

--- a/lib/presenters/event.js
+++ b/lib/presenters/event.js
@@ -85,6 +85,8 @@ function presentTicketTypes (types, event, type) {
       ticket.is_paid = ticket.ticket_type === 'paid';
       ticket.is_free = ticket.ticket_type === 'free';
       ticket.input_quantity_name = 'order[order_items_attributes]['+i+'][quantity]';
+      ticket.quantity_options_html =
+        quantityOptions(type.min_purchase || 1, type.max_purchase || 10);
     }
 
     else if (type === 'donation') {
@@ -116,4 +118,21 @@ function addGoal (event) {
     event.has_goal = true;
     event.campaign_goal_percent = Math.max(0, Math.min(1, perc));
   }
+}
+
+/*
+ * generates quantity <option> tags
+ */
+
+function quantityOptions (min, max) {
+  var options = [];
+
+  options.push('<option>0</option>');
+
+  for (var i = min; i <= max; i++) {
+    if (i !== 0)
+      options.push('<option>' + i + '</option>');
+  }
+
+  return options.join("");
 }

--- a/lib/presenters/event.js
+++ b/lib/presenters/event.js
@@ -86,7 +86,7 @@ function presentTicketTypes (types, event, type) {
       ticket.is_free = ticket.ticket_type === 'free';
       ticket.input_quantity_name = 'order[order_items_attributes]['+i+'][quantity]';
       ticket.quantity_options_html =
-        quantityOptions(type.min_purchase || 1, type.max_purchase || 10);
+        quantityOptions(ticket.min_purchase || 1, ticket.max_purchase || 10);
     }
 
     else if (type === 'donation') {
@@ -127,11 +127,11 @@ function addGoal (event) {
 function quantityOptions (min, max) {
   var options = [];
 
-  options.push('<option>0</option>');
+  options.push('<option value="0">0</option>');
 
   for (var i = min; i <= max; i++) {
     if (i !== 0)
-      options.push('<option>' + i + '</option>');
+      options.push('<option value="' + i + '">' + i + '</option>');
   }
 
   return options.join("");

--- a/lib/templates/ticket-form.html
+++ b/lib/templates/ticket-form.html
@@ -65,17 +65,7 @@
 
           <div class='{{tb}}-quantity'>
             <select name='{{input_quantity_name}}'>
-              <option>0</option>
-              <option>1</option>
-              <option>2</option>
-              <option>3</option>
-              <option>4</option>
-              <option>5</option>
-              <option>6</option>
-              <option>7</option>
-              <option>8</option>
-              <option>9</option>
-              <option>10</option>
+              {{{quantity_options_html}}}
             </select>
           </div>
         </div>

--- a/test/fixtures/event_ok.json
+++ b/test/fixtures/event_ok.json
@@ -14,19 +14,25 @@
         "formatted_fee": "$1.15"
       },
       "ticket_type": "paid",
-      "status": "live"
+      "status": "live",
+      "min_purchase": 1,
+      "max_purchase": 10
     },
     {
       "title": "General attendee",
       "price": "0",
       "ticket_type": "free",
-      "status": "live"
+      "status": "live",
+      "min_purchase": 1,
+      "max_purchase": 10
     },
     {
       "title": "Sold out ticket",
       "price": "0",
       "ticket_type": "free",
-      "status": "dead"
+      "status": "dead",
+      "min_purchase": 1,
+      "max_purchase": 10
     }
   ],
   "donation_types": [

--- a/test/tickets/single_ticket_test.js
+++ b/test/tickets/single_ticket_test.js
@@ -1,0 +1,44 @@
+require('../setup');
+var $select;
+
+describe('Single ticket:', function () {
+
+  var mock = mockWidget.bind(this, {
+    html:
+      "<div id='w' data-event='101' "+
+      "data-tb='ticket-form'></div>",
+    reply: require('../fixtures/event_ok.json')
+  });
+
+  describe("with min:1 max:10:", function () {
+    mock(function (event) {
+      event.ticket_types = [ event.ticket_types[0] ];
+      event.ticket_types[0].min_purchase = 1;
+      event.ticket_types[0].max_purchase = 10;
+    });
+
+    beforeEach(function () {
+      $select = $w.find('.tb-ticket').eq(0).find('select');
+    });
+
+    it('has quantity defaulting to 1', function () {
+      expect($select.val()).eql("1");
+    });
+  });
+
+  describe("with min:5 max:10:", function () {
+    mock(function (event) {
+      event.ticket_types = [ event.ticket_types[0] ];
+      event.ticket_types[0].min_purchase = 5;
+      event.ticket_types[0].max_purchase = 10;
+    });
+
+    beforeEach(function () {
+      $select = $w.find('.tb-ticket').eq(0).find('select');
+    });
+
+    it('has quantity defaulting to 5', function () {
+      expect($select.val()).eql("5");
+    });
+  });
+});

--- a/test/tickets/ticket_quantity_test.js
+++ b/test/tickets/ticket_quantity_test.js
@@ -1,0 +1,50 @@
+require('../setup');
+var $select;
+
+describe('Ticket quantitie:', function () {
+
+  var mock = mockWidget.bind(this, {
+    html:
+      "<div id='w' data-event='101' "+
+      "data-tb='ticket-form'></div>",
+    reply: require('../fixtures/event_ok.json')
+  });
+
+  describe("with min 1 max 3:", function () {
+    mock(function (event) {
+      event.ticket_types[0].min_purchase = 1;
+      event.ticket_types[0].max_purchase = 3;
+    });
+
+    beforeEach(function () {
+      $select = $w.find('.tb-ticket').eq(0).find('select');
+    });
+
+    it('generates 0 to 3', function () {
+      expect($select.find('option')).have.length(4);
+      expect($select.find('option[value="0"]')).have.length(1);
+      expect($select.find('option[value="1"]')).have.length(1);
+      expect($select.find('option[value="2"]')).have.length(1);
+      expect($select.find('option[value="3"]')).have.length(1);
+    });
+  });
+
+  describe("with min 5 max 7:", function () {
+    mock(function (event) {
+      event.ticket_types[0].min_purchase = 5;
+      event.ticket_types[0].max_purchase = 7;
+    });
+
+    beforeEach(function () {
+      $select = $w.find('.tb-ticket').eq(0).find('select');
+    });
+
+    it('generates 0, 5, 6, 7', function () {
+      expect($select.find('option')).have.length(4);
+      expect($select.find('option[value="0"]')).have.length(1);
+      expect($select.find('option[value="5"]')).have.length(1);
+      expect($select.find('option[value="6"]')).have.length(1);
+      expect($select.find('option[value="7"]')).have.length(1);
+    });
+  });
+});

--- a/test/tickets/ticket_types_test.js
+++ b/test/tickets/ticket_types_test.js
@@ -1,5 +1,5 @@
 require('../setup');
-var $item;
+var $item, $select;
 
 describe('Ticket types:', function () {
 
@@ -18,6 +18,8 @@ describe('Ticket types:', function () {
           description: 'Ticket description',
           status: 'live',
           ticket_type: 'paid',
+          min_purchase: 1,
+          max_purchase: 10,
           prices: {
             amount: 25,
             fee: 0.99,


### PR DESCRIPTION
The quantities listed will now honor a ticket's `min_purchase` and `max_purchase` amounts. It will still default to 1 and 10 (as per Ticketbase defaults), of course.

Also, the minimum purchase amount (usually `1`) will be pre-selected if the event only has one ticket available.

![pasted_image_4_9_15__6_00_pm](https://cloud.githubusercontent.com/assets/74385/7064573/48214a86-dee2-11e4-9fcf-5a754b1e395a.png)
