### PR TITLE
Updated uglify-js to version 2.4.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "sinon": "1.12.2",
     "stylify": "git://github.com/contra/stylify.git#resolve-uses",
     "stylus": "0.52.4",
-    "uglify-js": "2.4.16",
+    "uglify-js": "2.4.24",
     "watch": "0.16.0"
   },
   "directories": {


### PR DESCRIPTION
:rocket:

uglify-js just published version 2.4.24, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 116 commits (ahead by 116, behind by 0).
- [ba9936a](https://github.com/mishoo/UglifyJS2/commit/ba9936a5725f35c3d3452bf3aeba4055de1a1071): v2.4.24
- [905b601](https://github.com/mishoo/UglifyJS2/commit/905b6011784ca60d41919ac1a499962b7c1d4b02): Don't attempt to negate non-boolean AST_Binary
- [63fb2d5](https://github.com/mishoo/UglifyJS2/commit/63fb2d5a44db3d583b1927c8daa244bf9f4d8dd2): Merge pull request #735 from kzc/master
- [85a5fc0](https://github.com/mishoo/UglifyJS2/commit/85a5fc0aeb1785982506c09a484e12608ba01624): Don't drop parens in a \* (b \* c).  Close #744
- [9d398d9](https://github.com/mishoo/UglifyJS2/commit/9d398d999c67f6d2e74a5b07d5ce8d265391a698): spacing
- [f47b2b5](https://github.com/mishoo/UglifyJS2/commit/f47b2b52a5642cf7991329a2b635f8f1168dc8c9): operator && and || optimization: add "else" before "if" as intended
- [fedb619](https://github.com/mishoo/UglifyJS2/commit/fedb6191a11c2d868c23362e10f23795aae3ca3e): optimizations for && and || where left side is constant expression
- [5bf617e](https://github.com/mishoo/UglifyJS2/commit/5bf617ebde8edd0720477944f84f69c9adec078e): Merge pull request #733 from jcxplorer/add-mangle-regex-option
- [0b82e1c](https://github.com/mishoo/UglifyJS2/commit/0b82e1cd5b29e348700472cc711020e477d5e81a): Change --mangle-regex to accept a full regex
- [9aef34a](https://github.com/mishoo/UglifyJS2/commit/9aef34a8168f5de3bc00330a740c22de70314a70): Show descriptive error when --mangle-regex is invalid
- [0ac6918](https://github.com/mishoo/UglifyJS2/commit/0ac6918a411c85304dc716cd6de68b293a0d133a): Add --mangle-regex option
- [c6fa291](https://github.com/mishoo/UglifyJS2/commit/c6fa2915715f0a1a2b1527c23388bd7de56284c4): v2.4.23
- [bce4307](https://github.com/mishoo/UglifyJS2/commit/bce4307e9e1c22bcc00c83f9b51bb0bdb2f432b0): Treat \uFEFF as whitespace.
- [96ad94a](https://github.com/mishoo/UglifyJS2/commit/96ad94ab419ede17a5c931a1dc86416ea0c9d2a8): v2.4.22
- [a5b6021](https://github.com/mishoo/UglifyJS2/commit/a5b60217cede3f214153e62087d32274aa0859e5): Fix compressing conditionals

There are 116 commits in total. See the [full diff](https://github.com/mishoo/UglifyJS2/compare/5538ec7bd8a64c7fcc45895308a8463e4ca4d00a...ba9936a5725f35c3d3452bf3aeba4055de1a1071).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
