### PR TITLE
Updated jquery to version 2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "chai": "3.3.0",
     "chai-jquery": "2.0.0",
     "deep-extend": "0.4.0",
-    "jquery": "2.1.3",
+    "jquery": "2.1.4",
     "jsdom": "6.5.1",
     "mocha": "2.3.3",
     "mocha-clean": "0.4.0",


### PR DESCRIPTION
:rocket:

jquery just published version 2.1.4, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 5 commits (ahead by 5, behind by 1).
- [7751e69](https://github.com/jquery/jquery/commit/7751e69b615c6eca6f783a81e292a55725af6b85): 2.1.4
- [64f7d10](https://github.com/jquery/jquery/commit/64f7d10980a5e9f2862f1239a37d95e6c39e37ec): Core: add workaround for iOS JIT error in isArrayLike
- [a4a18e8](https://github.com/jquery/jquery/commit/a4a18e84ec89d862e5dbbea9d04ce05dfdf90554): Data: Drop the tests relying on applets
- [136f1dc](https://github.com/jquery/jquery/commit/136f1dc52bcb9db36122195401c692b26e21578a): Build: Don't publish dist/cdn to npm/Bower
- [cddeb7c](https://github.com/jquery/jquery/commit/cddeb7c1c2dbf9d3f6f7b9ca30230b021417a70f): Build: Updating the 2.1-stable version to 2.1.4-pre.

See the [full diff](https://github.com/jquery/jquery/compare/8f2a9d9272d6ed7f32d3a484740ab342c02541e0...7751e69b615c6eca6f783a81e292a55725af6b85).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
